### PR TITLE
멤버 삭제 구현

### DIFF
--- a/.tags
+++ b/.tags
@@ -42,7 +42,6 @@ UserMessenger	app/models/user_messenger.rb	/^class UserMessenger < ActiveRecord:
 UserMessengerTest	test/models/user_messenger_test.rb	/^class UserMessengerTest < ActiveSupport::TestCase$/;"	c
 UserTest	test/models/user_test.rb	/^class UserTest < ActiveSupport::TestCase$/;"	c
 add_member	app/controllers/members_controller.rb	/^  def add_member$/;"	f	class:MembersController
-add_user_response	app/controllers/members_controller.rb	/^    def add_user_response(meetup)$/;"	f	class:MembersController
 authorize_params	app/controllers/application_controller.rb	/^  def authorize_params$/;"	f	class:ApplicationController
 change	db/migrate/20160719100000_create_code_tables.rb	/^  def change$/;"	f	class:CreateCodeTables
 change	db/migrate/20160719103245_create_users.rb	/^  def change$/;"	f	class:CreateUsers
@@ -53,12 +52,15 @@ change	db/migrate/20160719103627_create_meal_logs.rb	/^  def change$/;"	f	class:
 change	db/migrate/20160719103931_create_meal_meet_up_logs.rb	/^  def change$/;"	f	class:CreateMealMeetUpLogs
 change	db/migrate/20160719135136_change_code_table_column.rb	/^  def change$/;"	f	class:ChangeCodeTableColumn
 change	db/migrate/20160729122925_change_user_and_messenger.rb	/^  def change$/;"	f	class:ChangeUserAndMessenger
+check_add_member	app/controllers/members_controller.rb	/^    def check_add_member$/;"	f	class:MembersController
+check_delete_member	app/controllers/members_controller.rb	/^    def check_delete_member$/;"	f	class:MembersController
 check_meetup_create	app/controllers/meal_meet_up_controller.rb	/^    def check_meetup_create$/;"	f	class:MealMeetUpController
 check_meetup_update	app/controllers/meal_meet_up_controller.rb	/^    def check_meetup_update$/;"	f	class:MealMeetUpController
-check_member_info	app/controllers/members_controller.rb	/^    def check_member_info$/;"	f	class:MembersController
 check_menu_info	app/controllers/meet_up_tasks_controller.rb	/^    def check_menu_info$/;"	f	class:MeetUpTasksController
 check_update_info	app/controllers/meet_up_tasks_controller.rb	/^    def check_update_info$/;"	f	class:MeetUpTasksController
 create	app/controllers/meal_meet_up_controller.rb	/^  def create$/;"	f	class:MealMeetUpController
+delete_member	app/controllers/members_controller.rb	/^  def delete_member$/;"	f	class:MembersController
+delete_member	app/models/user.rb	/^  def self.delete_member(member_uid, meetup)$/;"	F	class:User
 enroll_exist_user	app/models/user.rb	/^  def self.enroll_exist_user(user, meetup, task_code)$/;"	F	class:User
 enroll_new_user	app/models/user.rb	/^  def self.enroll_new_user(member_uid, meetup, messenger_code, task_code)$/;"	F	class:User
 enrolled_user	app/models/user.rb	/^  def self.enrolled_user?(user_id, meetup)$/;"	F	class:User
@@ -74,6 +76,7 @@ load_messenger_code	app/controllers/application_controller.rb	/^  def load_messe
 load_task_code	app/controllers/application_controller.rb	/^  def load_task_code(task)$/;"	f	class:ApplicationController
 meetup_params	app/controllers/meal_meet_up_controller.rb	/^    def meetup_params$/;"	f	class:MealMeetUpController
 member_params	app/controllers/members_controller.rb	/^    def member_params$/;"	f	class:MembersController
+member_response	app/controllers/members_controller.rb	/^    def member_response(meetup)$/;"	f	class:MembersController
 menu	app/controllers/meet_up_tasks_controller.rb	/^  def menu$/;"	f	class:MeetUpTasksController
 menu_response	app/controllers/meet_up_tasks_controller.rb	/^    def menu_response(meetup, meal_log)$/;"	f	class:MeetUpTasksController
 params_authorizable?	app/controllers/meal_meet_up_controller.rb	/^    def params_authorizable?$/;"	f	class:MealMeetUpController

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,16 +1,23 @@
 # Members Controller
 class MembersController < ApplicationController
-  before_action :authorize_params, only: [:add_member]
-  before_action :check_member_info, only: [:add_member]
-  before_action :find_meetup, only: [:add_member]
+  before_action :authorize_params, only: [:add_member, :delete_member]
+  before_action :check_add_member, only: [:add_member]
+  before_action :check_delete_member, only: [:delete_member]
+  before_action :find_meetup, only: [:add_member, :delete_member]
   def add_member
-    entry_member = member_params[:member_id]
+    entry_member = member_params[:member_id].to_s
     task_unpaid = load_task_code('unpaid')
-    unless get_members_list(@meetup).include?(entry_member.to_s)
+    unless get_members_list(@meetup).include?(entry_member)
       User.init_member(entry_member, @meetup,
                        load_messenger_code(member_params), task_unpaid)
     end
-    render_200(add_user_response(find_meetup)) # 새로 MeetUp을 로딩해야 올바른 목록이 나온다.
+    render_200(member_response(find_meetup)) # 새로 MeetUp을 로딩해야 올바른 목록이 나온다.
+  end
+
+  def delete_member
+    target_member = member_params[:member_id].to_s
+    User.delete_member(target_member, @meetup)
+    render_200(member_response(find_meetup))
   end
 
   private
@@ -20,7 +27,7 @@ class MembersController < ApplicationController
                                    :messenger_room_id, :member_id)
     end
 
-    def check_member_info
+    def check_add_member
       meetup = find_meetup
       if meetup.nil?
         render json: { error: 'cannot find meetup' }, status: 400
@@ -31,13 +38,26 @@ class MembersController < ApplicationController
       end
     end
 
+    def check_delete_member
+      meetup = find_meetup
+      member_id = member_params[:member_id].to_s
+      if meetup.nil?
+        render json: { error: 'cannot find meetup' }, status: 400
+      elsif meetup.admin.service_uid == member_id
+        render json: { error: 'cannot delete admin member' }, status: 400
+      elsif !get_members_list(meetup).include?(member_id)
+        render json: { error: 'cannot find the member_id in this meetup' },
+               status: 400
+      end
+    end
+
     def params_authorizable?
       [member_params[:messenger], member_params[:messenger_room_id]].all? do |e|
         !e.to_s.empty?
       end
     end
 
-    def add_user_response(meetup)
+    def member_response(meetup)
       { data:
         { messenger: meetup.messenger.value,
           messenger_room_id: meetup.messenger_room_id,

--- a/app/models/meal_log.rb
+++ b/app/models/meal_log.rb
@@ -1,5 +1,5 @@
 # Meal Log model
 class MealLog < ActiveRecord::Base
-  has_one :meal_meet_up_task
+  has_one :meal_meet_up_task, dependent: :destroy
   belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,12 @@ class User < ActiveRecord::Base
     result # Admin 등록을 위해 user정보가 리턴되어야 함
   end
 
+  def self.delete_member(member_uid, meetup)
+    user = find_by(service_uid: member_uid)
+    target_log = user.find_enrolled_meetup(meetup.id)
+    target_log.destroy
+  end
+
   # DB에 기록되어있지 않은 맴버를 새로 생성
   def self.enroll_new_user(member_uid, meetup, messenger_code, task_code)
     user = User.create(service_uid: member_uid)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   patch 'meal_meet_ups' => 'meal_meet_up#update', defaults: { format: 'json' }
 
   post 'members' => 'members#add_member', defaults: { format: 'json' }
+  delete 'members' => 'members#delete_member', defaults: { format: 'json' }
 
   put 'meal_meet_up_tasks/menu'   => 'meet_up_tasks#menu',   defaults: { format: 'json' }
   patch 'meal_meet_up_tasks/update' => 'meet_up_tasks#update', defaults: { format: 'json' }


### PR DESCRIPTION
MeetUp에 등록된 멤버들을 하나씩 삭제하는 기능 구현
- admin_uid는 삭제 불가
- 처음 서버에 멤버를 등록 시 저장되는 User정보 (service_uid, messenger 정보)는 보관
- MeetUp에 등록된 당시 멤버의 MealLog, MealMeetUpTask만 삭제
- 삭제 이후 MeetUp에 남아있는 멤버들 리턴
